### PR TITLE
fix: fill full viewport height on mobile landscape

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -15,6 +15,12 @@
 
 * { box-sizing: border-box; }
 
+/* Ensure html fills the viewport for dvh/fill-available to work correctly on mobile */
+html {
+  height: 100%;
+  height: -webkit-fill-available;
+}
+
 body {
   margin: 0;
   min-height: 100vh;
@@ -325,7 +331,12 @@ body[data-ui-mode="mobile"] {
   padding: 0;
   margin: 0;
   display: flex;
-  place-items: stretch;
+  flex-direction: column;
+  width: 100vw;
+  height: 100dvh;
+  /* Fallback for browsers without dvh support */
+  height: -webkit-fill-available;
+  height: 100dvh;
 }
 
 body[data-ui-mode="mobile"] .app {
@@ -343,9 +354,16 @@ body[data-ui-mode="mobile"] .app {
 
 /* 端末が既に横向きの場合: そのままビューポートいっぱい */
 @media (orientation: landscape) {
+  body[data-ui-mode="mobile"] {
+    width: 100vw;
+    height: 100dvh;
+    /* Ensure no browser UI shrinks the viewport on landscape mobile */
+    min-height: -webkit-fill-available;
+  }
   body[data-ui-mode="mobile"] .app {
     width: 100vw;
     height: 100dvh;
+    min-height: 0;
   }
 }
 
@@ -709,7 +727,7 @@ button.primary {
 .judge-miss { color: var(--miss); }
 
 @media (max-width: 700px) {
-  body {
+  body:not([data-ui-mode="mobile"]) {
     overflow-y: auto;
     overflow-x: hidden;
     align-items: start;
@@ -814,7 +832,7 @@ button.primary {
 
 /* Galaxy S23 class phones (360x780 around) */
 @media (max-width: 390px) and (max-height: 900px) {
-  body {
+  body:not([data-ui-mode="mobile"]) {
     padding: 4px 0 10px;
   }
 


### PR DESCRIPTION
## Problem

On mobile in landscape orientation, the game play screen only fills the top half of the screen. The notes/staff area is squished into the upper portion instead of filling the full viewport height.

## Root Causes

Three overlapping CSS issues in `src/styles.css` combined to produce the half-screen bug:

1. **`body[data-ui-mode="mobile"]` lacked an explicit height** - it used `display: flex` but `place-items: stretch` is a grid-only property with no effect in flex context. The body had only `min-height: 100dvh` (on the base `body` rule), not `height: 100dvh`. The flex container therefore sized to its content, and the child `.app` with `height: 100dvh` overflowed rather than filling the body.

2. **`@media (max-width: 700px)` unconditionally overrode `body`** - setting `padding: 8px 0 14px`, `overflow-y: auto`, and `align-items: start` on all bodies including mobile mode, breaking the zero-padding full-screen layout.

3. **`@media (max-width: 390px) and (max-height: 900px)` (Galaxy S23 rule)** similarly forced `body { padding: 4px 0 10px }` in mobile mode.

## Changes to `src/styles.css`

| Location | Change |
|---|---|
| Top of file | Added `html { height: 100%; height: -webkit-fill-available }` so `dvh` units have a properly sized reference frame on iOS Safari |
| `body[data-ui-mode="mobile"]` | Replaced `display: flex; place-items: stretch` with `display: flex; flex-direction: column; width: 100vw; height: 100dvh` plus `-webkit-fill-available` fallback |
| `@media (orientation: landscape)` | Added `body[data-ui-mode="mobile"]` height fix and `min-height: 0` on `.app` to prevent flex overflow |
| `@media (max-width: 700px)` | Changed `body { ... }` to `body:not([data-ui-mode="mobile"]) { ... }` |
| `@media (max-width: 390px) and (max-height: 900px)` | Changed `body { padding }` to `body:not([data-ui-mode="mobile"]) { padding }` |

## Test Plan

- [ ] Open on a mobile device (or DevTools mobile simulation) in landscape orientation
- [ ] Verify the play field fills the full screen height
- [ ] Verify portrait mode still shows the rotate prompt
- [ ] Verify desktop layout is unchanged
- [ ] Verify small-screen non-mobile browsers (<=700px viewport width) still have correct padding/scroll

Generated with [Claude Code](https://claude.com/claude-code)