### PR TITLE
fix: use position:fixed for mobile landscape blank screen

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -18,8 +18,6 @@
 /* Ensure html fills the viewport for dvh/fill-available to work correctly on mobile */
 html {
   height: 100%;
-  /* iOS Safari: make html fill the true visible area */
-  height: -webkit-fill-available;
 }
 
 body {
@@ -363,22 +361,20 @@ body[data-ui-mode="mobile"] .app {
   max-width: 100vw;
 }
 
-/* 端末が既に横向きの場合: そのままビューポートいっぱい */
+/* 端末が既に横向きの場合: position:fixed で確実に全画面表示 */
 @media (orientation: landscape) {
   body[data-ui-mode="mobile"] {
-    width: 100vw;
-    /* Use svh (small viewport height) in landscape to exclude browser chrome;
-       fall back to dvh then -webkit-fill-available for iOS Safari */
-    height: 100vh;
-    height: 100dvh;
-    height: -webkit-fill-available;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
     min-height: 0;
+    overflow: hidden;
   }
   body[data-ui-mode="mobile"] .app {
-    width: 100vw;
-    height: 100vh;
-    height: 100dvh;
-    height: -webkit-fill-available;
+    width: 100%;
+    height: 100%;
     min-height: 0;
   }
 }


### PR DESCRIPTION
## 問題

PR #11 のCSS修正後、スマホ横向きでゲーム画面が真っ白になった。

## 原因

`html` と `body` の両方に `height: -webkit-fill-available` が設定されていたため、一部のAndroid Chrome で両方が `0` に計算され、画面が真っ白になっていた。

具体的には：
1. `html { height: -webkit-fill-available }` — htmlの高さが不定に
2. `@media(orientation:landscape)` の `body[data-ui-mode="mobile"] { height: -webkit-fill-available }` — bodyもhtmlから継承した0を参照

この連鎖で `.app` の高さが 0 になり、コンテンツが非表示に。

## 修正内容

**Fix 1**: `html` から `height: -webkit-fill-available` を削除。`html { height: 100% }` のみにして確実なパーセント基点を提供。

**Fix 2**: `@media (orientation: landscape)` 内の `body[data-ui-mode="mobile"]` で、不安定な `dvh/-webkit-fill-available` スタックを `position: fixed; top: 0; left: 0; width: 100%; height: 100%` に置き換え。これが全モバイルブラウザで最も確実な全画面表示手法。

## 変更ファイル

- `src/styles.css` のみ（ゲームロジック変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)