### PR TITLE
fix: タッチ座標ズレ修正 - bodyでなく.appにposition:fixed

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -361,23 +361,25 @@ body[data-ui-mode="mobile"] .app {
   max-width: 100vw;
 }
 
-/* 端末が既に横向きの場合: position:fixed で確実に全画面表示
-   Android Chrome では html+body 両方に -webkit-fill-available を
-   チェーンすると高さが 0 になるバグがある。position:fixed + height:100% で回避する。 */
+/* 端末が既に横向きの場合: .app に position:fixed を当てて確実に全画面表示
+   body に position:fixed を当てると Android/iOS でタッチ座標がズレる問題があるため
+   body はそのままにし、.app 側を fixed にする。
+   .app が固定要素になるので position:absolute な子（オーバーレイ等）の基点にもなる。 */
 @media (orientation: landscape) {
   body[data-ui-mode="mobile"] {
+    overflow: hidden;
+    height: 100vh;
+    height: 100dvh;
+  }
+  body[data-ui-mode="mobile"] .app {
     position: fixed;
     top: 0;
     left: 0;
-    width: 100%;
-    height: 100%;
+    width: 100vw;
+    height: 100vh;
+    height: 100dvh;
     min-height: 0;
     overflow: hidden;
-  }
-  body[data-ui-mode="mobile"] .app {
-    width: 100%;
-    height: 100%;
-    min-height: 0;
   }
 }
 


### PR DESCRIPTION
## 原因
body に position:fixed を当てると、Android/iOS でタッチイベントの座標がビジュアル位置とズレる問題が発生。

「タップしてスタート」オーバーレイを押しても反応しない原因はこれ。

## 修正
body には固定を当てず、.app 自体に `position: fixed; top:0; left:0; width:100vw; height:100dvh` を適用。
- .app が固定要素になるため、position:absolute な子要素（スタートオーバーレイ等）の基点にもなる
- タッチ座標は .app の視覚位置と一致するため、タップが正常に機能する