### PR TITLE
fix: resolve half-screen on mobile landscape with flex height propagation

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -471,12 +471,19 @@ body[data-ui-mode="mobile"] .playfield-wrap {
   flex: 1 1 0;
   min-height: 0;
   width: 100%;
-  display: block;
+  /* Use flex container so .playfield can fill reliably via flex:1.
+     height:100% on a block child of a flex item is unreliable in many
+     mobile browsers (Android Chrome, iOS Safari) — flex:1 is the safe fix. */
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 body[data-ui-mode="mobile"] .playfield {
   width: 100% !important;
-  height: 100% !important;
+  /* flex:1 fills the flex-column .playfield-wrap reliably on all mobile browsers */
+  flex: 1 1 0 !important;
+  min-height: 0 !important;
   max-height: none !important;
   border-width: 1px;
   border-radius: 0;


### PR DESCRIPTION
## 原因

`.playfield-wrap` が `display: block` の flex アイテムで、子の `.playfield` が `height: 100%` を使っていた。

**`height: 100%` on a block child of a flex item** はモバイルブラウザ（Android Chrome・iOS Safari）で **不安定**。flex アイテムの flex-assigned サイズがパーセント高さの解決に使われない実装が存在する。

## 修正内容

- `.playfield-wrap` を `display: flex; flex-direction: column; overflow: hidden` に変更
- `.playfield` の `height: 100% !important` を `flex: 1 1 0 !important; min-height: 0 !important` に変更

flex コンテナ内の `flex: 1` は全ブラウザで確実に動作し、高さが正確に継承される。

## 修正前後のスタック

```
body[data-ui-mode="mobile"].app (position:fixed, flex-col, 100dvh)
  └─ .mobile-toolbar (flex-shrink:0)
  └─ .playfield-wrap (flex:1 → ★display:flex,flex-col を追加)
       └─ .playfield (height:100% → ★flex:1 1 0 に変更)
```

Closes #15（半分表示バグ）