### PR TITLE
fix: Mobile playfield not filling screen

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -483,6 +483,8 @@ body[data-ui-mode="mobile"] .playfield-wrap {
 
 body[data-ui-mode="mobile"] .playfield {
   width: 100% !important;
+  /* Reset any explicit height from responsive media queries so flex controls sizing */
+  height: auto !important;
   /* flex:1 fills the flex-column .playfield-wrap reliably on all mobile browsers */
   flex: 1 1 0 !important;
   min-height: 0 !important;


### PR DESCRIPTION
## Summary
- Responsive media queries were setting explicit `height` (e.g. `58svh`) on `.playfield` that overrode `flex: 1 1 0` in mobile mode
- Added `height: auto !important` to the mobile playfield rule to ensure flex layout controls the height
- Fixes the issue where the playfield/judge line only appeared in the top ~1/3 of the screen on mobile

## Test plan
- [ ] Open on mobile phone in landscape → playfield fills entire screen
- [ ] Judge line appears near the bottom, not the top
- [ ] Desktop layout unchanged