### PR TITLE
fix: use inset:0 for fixed landscape app (fill full viewport)

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -374,12 +374,8 @@ body[data-ui-mode="mobile"] .app {
   }
   body[data-ui-mode="mobile"] .app {
     position: fixed;
-    top: 0;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
-    height: 100dvh;
-    height: var(--device-h, 100dvh);
+    inset: 0; /* fill entire viewport — avoids --device-h rounding/timing gaps */
+    width: 100vw; /* belt-and-suspenders for older Safari */
     min-height: 0;
     overflow: hidden;
   }


### PR DESCRIPTION
## Problem
`body[data-ui-mode="mobile"] .app` in landscape was using:
```css
height: 100vh;
height: 100dvh;
height: var(--device-h, 100dvh);
```
The `--device-h` value is set via JS from `visualViewport.height`, but there can be rounding errors, timing gaps (set after first paint), or platform-specific differences — leaving unused space at the bottom of the screen.

## Fix
Replace `top: 0; left: 0; width: 100vw; height: var(--device-h, 100dvh)` with `inset: 0` on the `position: fixed` element.

For `position: fixed`, `inset: 0` (= `top:0; right:0; bottom:0; left:0`) anchors the element to all 4 edges of the viewport — no JS measurement or height calculation needed, zero gap guaranteed.

## Test plan
- [ ] Open on iPhone in landscape → app fills all the way to bottom edge
- [ ] Open on Android Chrome in landscape → same
- [ ] Judge line visible near bottom, no black gap below playfield
- [ ] Touch/tap still registers correctly (position: fixed maintains correct coords)
