### PR TITLE
fix: add height:auto !important to landscape app so inset:0 fills full viewport

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -374,8 +374,9 @@ body[data-ui-mode="mobile"] .app {
   }
   body[data-ui-mode="mobile"] .app {
     position: fixed;
-    inset: 0; /* fill entire viewport — avoids --device-h rounding/timing gaps */
-    width: 100vw; /* belt-and-suspenders for older Safari */
+    inset: 0; /* anchor to all 4 viewport edges */
+    width: 100vw;
+    height: auto !important; /* reset height so inset bottom:0 controls sizing, not --device-h */
     min-height: 0;
     overflow: hidden;
   }


### PR DESCRIPTION
In `@media (orientation: landscape)`, `body[data-ui-mode="mobile"] .app` had `inset: 0` but the non-landscape rule also sets `height: var(--device-h, 100dvh)`. For `position: fixed`, when both `top`+`bottom` (from `inset:0`) AND `height` are explicitly set, `height` wins — so the element only stretched to `--device-h` instead of filling to the bottom.

Fix: added `height: auto !important` inside the landscape block to reset the height so that `inset: 0` (bottom: 0) controls the sizing.