### PR TITLE
fix: Chromeモバイル全画面表示崩れ + マルチタッチstuck-hold不具合

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2418,6 +2418,7 @@ export default function App(): JSX.Element {
                   onPointerDown={() => onLanePointerDown(i)}
                   onPointerUp={() => { runtimeRef.current.lanePressed[i] = false; }}
                   onPointerLeave={() => { runtimeRef.current.lanePressed[i] = false; }}
+                  onPointerCancel={() => { runtimeRef.current.lanePressed[i] = false; }}
                 />
               ))}
             </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -26,9 +26,6 @@ body {
   min-height: 100vh;
   /* Modern browsers: use dynamic viewport height (excludes browser chrome) */
   min-height: 100dvh;
-  /* iOS Safari fallback: -webkit-fill-available must come last to override 100dvh
-     on Safari versions that have the 100vh/dvh bug */
-  min-height: -webkit-fill-available;
   font-family: "Zen Kaku Gothic New", sans-serif;
   color: var(--text);
   background:
@@ -41,6 +38,16 @@ body {
   overscroll-behavior: none;
   -webkit-user-select: none;
   user-select: none;
+}
+
+/* -webkit-fill-available is only needed by browsers without dvh support (old iOS Safari).
+   Gated behind @supports so it can't win the cascade on browsers (e.g. Chrome/Android) that
+   parse the value but don't size it the same way dvh does — that mismatch was cutting the
+   playfield short on Chrome while unaffected engines (LINE in-app browser) looked fine. */
+@supports not (height: 100dvh) {
+  body {
+    min-height: -webkit-fill-available;
+  }
 }
 
 .bg-glow {
@@ -333,9 +340,14 @@ body[data-ui-mode="mobile"] {
   margin: 0;
   height: 100vh;
   height: 100dvh;
-  height: -webkit-fill-available;
   min-height: 0;
   display: block;
+}
+
+@supports not (height: 100dvh) {
+  body[data-ui-mode="mobile"] {
+    height: -webkit-fill-available;
+  }
 }
 
 body[data-ui-mode="mobile"] .app {


### PR DESCRIPTION
## 概要

Issue #30, #31 で指摘されていた2件の不具合を修正．

## #30: スマホChromeで譜面が全画面表示にならない

`body` / `body[data-ui-mode="mobile"]` の高さ指定が
`100vh` → `100dvh` → `-webkit-fill-available` の順で並んでおり，
CSSカスケードのルール上「後に書かれた宣言が有効な限り勝つ」ため，
Chrome（Blink）が `-webkit-fill-available` を（Safariと異なる算出結果で）
解釈できてしまい，本来 iOS Safari 専用のフォールバックのはずが
dvh 対応の Chrome でも `100dvh` を上書きしていた．

`@supports not (height: 100dvh) { ... -webkit-fill-available ... }` で
ガードし，dvh 非対応ブラウザにのみフォールバックが適用されるよう修正．

## #31: 複数同時押し（マルチタッチ）調査

`touch-action: none` は既に `.lane` に設定済みで問題なし．
一方で `onPointerCancel` ハンドラが未実装だったため，OS側のジェス
チャー割り込み等で `pointercancel` が発生すると `lanePressed[i]` が
`true` のまま固着し，ホールドノーツが解放されない不具合があった．
`onPointerUp` / `onPointerLeave` と同様に状態をリセットする
`onPointerCancel` を追加．

## テスト

- `npm run build` 成功（tsc + vite build，警告なし）
- 実機テスト（2本指・3本指同時押し，Chrome実機での全画面表示）は
  未実施．CSS/JSロジックの静的な妥当性のみ確認済み．